### PR TITLE
Fix claim roundoff and UI number formatting

### DIFF
--- a/src/views/Pools/components/PoolCard/CardActions/index.tsx
+++ b/src/views/Pools/components/PoolCard/CardActions/index.tsx
@@ -6,7 +6,7 @@ import { Flex, Text, Box } from '@pancakeswap/uikit'
 import { useTranslation } from 'contexts/Localization'
 import { PoolCategory } from 'config/constants/types'
 import { Pool } from 'state/types'
-import { getBalanceNumber } from 'utils/formatBalance'
+import { getBalanceNumber, formatNumber } from 'utils/formatBalance'
 import ApprovalAction from './ApprovalAction'
 import StakeActions from './StakeActions'
 import HarvestActions from './HarvestActions'
@@ -40,8 +40,8 @@ const CardActions: React.FC<CardActionsProps> = ({ pool, stakedBalance }) => {
   const isStaked = stakedBalance.gt(0)
   const isLoading = !userData
 
-  const totalStaked = userData?.stakedBalance ? getBalanceNumber(new BigNumber(userData.stakedBalance), stakingToken.decimals) : BIG_ZERO
-  const totalEarned = userData?.pendingReward ? getBalanceNumber(new BigNumber(userData.pendingReward)) : BIG_ZERO
+  const totalStaked = userData?.stakedBalance ? getBalanceNumber(new BigNumber(userData.stakedBalance), stakingToken.decimals) : 0
+  const totalEarned = userData?.pendingReward ? getBalanceNumber(new BigNumber(userData.pendingReward)) : 0
 
   return (
     <Flex flexDirection="column">
@@ -66,13 +66,13 @@ const CardActions: React.FC<CardActionsProps> = ({ pool, stakedBalance }) => {
               <Box display="inline">
                 {/* <Text color="text" textTransform="uppercase"  bold fontSize="12px"> */}
                 <Text color="text" textTransform="uppercase" fontSize="12px">
-                   {!isComingSoon && totalStaked} {isComingSoon && '-'} {stakingToken.symbol}
+                   {!isComingSoon && formatNumber(totalStaked,2,5)} {isComingSoon && '-'} {stakingToken.symbol}
                 </Text>
               </Box>
               <Box display="inline">
                 {/* <Text color="text" textTransform="uppercase" bold fontSize="12px"> */}
                 <Text color="text" textTransform="uppercase" fontSize="12px">
-                   {!isComingSoon && totalEarned} {isComingSoon && '-'} {stakingToken.symbol}
+                   {!isComingSoon && formatNumber(totalEarned,2,5)} {isComingSoon && '-'} {stakingToken.symbol}
                 </Text>
               </Box>
             </Flex>

--- a/src/views/Pools/components/PoolCard/Modals/StakeModal.tsx
+++ b/src/views/Pools/components/PoolCard/Modals/StakeModal.tsx
@@ -11,7 +11,7 @@ import useTheme from 'hooks/useTheme'
 import useToast from 'hooks/useToast'
 import { useSousHarvest } from 'hooks/useHarvest'
 import BigNumber from 'bignumber.js'
-import { getFullDisplayBalance, formatNumber, getDecimalAmount, getBalanceNumber } from 'utils/formatBalance'
+import { getFullDisplayBalance, formatNumber, getBalanceNumber } from 'utils/formatBalance'
 import { BIG_ZERO } from 'utils/bigNumber'
 import useTokenBalance from 'hooks/useTokenBalance'
 import { Pool } from 'state/types'
@@ -58,15 +58,14 @@ const StakeModal: React.FC<StakeModalProps> = ({
   const [activeSelect, setActiveSelect] = useState(false)
   const { balance: earnedTokenBalance } = useTokenBalance(pool.earningToken.address[56])
   const { toastSuccess, toastError } = useToast()
-  const totalStakingTokens = userData?.stakingTokenBalance ? getBalanceNumber(new BigNumber(userData.stakingTokenBalance), stakingToken.decimals) : BIG_ZERO
-  const totalStakedTokens = userData?.stakedBalance ? getBalanceNumber(new BigNumber(userData.stakedBalance), stakingToken.decimals) : BIG_ZERO
-  const totalEarningTokens = earnedTokenBalance ? getBalanceNumber(new BigNumber(earnedTokenBalance)) : BIG_ZERO
-  const totalEarnedTokens = userData?.pendingReward ? getBalanceNumber(new BigNumber(userData.pendingReward)) : BIG_ZERO
+  const totalStakingTokens = userData?.stakingTokenBalance ? getBalanceNumber(new BigNumber(userData.stakingTokenBalance), stakingToken.decimals) : 0
+  const totalStakedTokens = userData?.stakedBalance ? getBalanceNumber(new BigNumber(userData.stakedBalance), stakingToken.decimals) : 0
+  const totalEarningTokens = earnedTokenBalance ? getBalanceNumber(new BigNumber(earnedTokenBalance)) : 0
+  const totalEarnedTokens = userData?.pendingReward ? getBalanceNumber(new BigNumber(userData.pendingReward)) : 0
   const [pendingTx, setPendingTx] = useState(false)
   const temp = new BigNumber(pool.tokenPerBlock).times( new BigNumber(userData.stakedBalance).div(pool.totalStaked)  ) 
-  const totalStaked = pool.totalStaked ? getBalanceNumber(new BigNumber(pool.totalStaked.toString()), stakingToken.decimals) : BIG_ZERO
 
-  const rewardRate = pool?.tokenPerBlock ? getBalanceNumber(temp) : BIG_ZERO
+  const rewardRate = pool?.tokenPerBlock ? getBalanceNumber(temp) : 0
   const [ onPresentStakeAction ] = useModal(<StakeTokenModal isBnbPool={isBnbPool} pool={pool} stakingTokenBalance={stakingTokenBalance} stakingTokenPrice={stakingTokenPrice} />)
   
   const handleHarvestConfirm = async () => {
@@ -120,12 +119,12 @@ const StakeModal: React.FC<StakeModalProps> = ({
       {pool.stakingToken.symbol === pool.earningToken.symbol ? 
         <StyledFlex marginTop="21px">
         <Flex flexDirection="column">
-          <Text fontSize="24px">{totalStakingTokens.toFixed(4)}</Text>
+          <Text fontSize="24px">{formatNumber(totalStakingTokens,2,5)}</Text>
           <Text color="textSubtle" marginBottom="24px">{pool.stakingToken.symbol} Tokens</Text>
           <Button fullWidth as="a" href={`https://sparkswap.finance/#/swap/${pool.stakingToken.address[56]}`}>Add More</Button>
         </Flex>
         <Flex flexDirection="column">
-          <Text fontSize="24px">{totalStakedTokens.toFixed(4)}</Text>
+          <Text fontSize="24px">{formatNumber(totalStakedTokens,2,5)}</Text>
           <Text color="textSubtle" marginBottom="24px">{pool.stakingToken.symbol} Staked</Text>
           <Button fullWidth onClick={onPresentStakeAction}>Stake Tokens</Button>
         </Flex>
@@ -134,17 +133,17 @@ const StakeModal: React.FC<StakeModalProps> = ({
         // Render two 'Add More' button components when staking token symbol is not equal to earning token symbol
         <StyledFlex marginTop="21px">
         <Flex flexDirection="column">
-          <Text fontSize="24px">{totalStakingTokens.toFixed(4)}</Text>
+          <Text fontSize="24px">{formatNumber(totalStakingTokens,2,5)}</Text>
           <Text color="textSubtle" marginBottom="24px">{pool.stakingToken.symbol} Tokens</Text>
           <Button fullWidth as="a" href={`https://sparkswap.finance/#/swap/${pool.stakingToken.address[56]}`}>Add More</Button>
         </Flex>
         <Flex flexDirection="column">
-          <Text fontSize="24px">{totalEarningTokens.toFixed(4)}</Text>
+          <Text fontSize="24px">{formatNumber(totalEarningTokens,2,5)}</Text>
           <Text color="textSubtle" marginBottom="24px">{pool.earningToken.symbol} Tokens</Text>
           <Button fullWidth as="a" href={`https://sparkswap.finance/#/swap/${pool.earningToken.address[56]}`}>Add More</Button>
         </Flex>
         <Flex flexDirection="column">
-          <Text fontSize="24px">{totalStakedTokens.toFixed(4)}</Text>
+          <Text fontSize="24px">{formatNumber(totalStakedTokens,2,5)}</Text>
           <Text color="textSubtle" marginBottom="24px">{pool.stakingToken.symbol} Staked</Text>
           <Button fullWidth onClick={onPresentStakeAction}>Stake Tokens</Button>
         </Flex>
@@ -156,11 +155,11 @@ const StakeModal: React.FC<StakeModalProps> = ({
       </StyledFlex>
       <StyledFlex marginTop="30px" marginBottom="20px">
         <Flex flexDirection="column">
-          <Text fontSize="24px">{rewardRate.toFixed(4)}</Text>
+          <Text fontSize="24px">{formatNumber(rewardRate,2,10)}</Text>
           <Text color="textSubtle" fontSize="17px">Your Rate {pool.earningToken.symbol}/block</Text>
         </Flex>
         <Flex flexDirection="column">
-          <Text fontSize="24px">{totalEarnedTokens.toFixed(4)}</Text>
+          <Text fontSize="24px">{formatNumber(totalEarnedTokens,2,5)}</Text>
           <Text color="textSubtle" fontSize="17px">{pool.earningToken.symbol} Token Earnings</Text>
         </Flex>
         <Flex flexDirection="column" mb="16px" marginLeft="5px"

--- a/src/views/Pools/components/PoolCard/Modals/StakeModal.tsx
+++ b/src/views/Pools/components/PoolCard/Modals/StakeModal.tsx
@@ -91,7 +91,7 @@ const StakeModal: React.FC<StakeModalProps> = ({
     setPendingTx(true)
       // unstaking
       try {
-        await onUnstake(totalStakedTokens.toString(), stakingToken.decimals)
+        await onUnstake(getFullDisplayBalance(new BigNumber(userData.stakedBalance), stakingToken.decimals, 18) , stakingToken.decimals)
         toastSuccess(
           `${t('Unstaked')}!`,
           t('Your %symbol% earnings have also been claimed to your wallet!', {

--- a/src/views/Pools/components/PoolCard/index.tsx
+++ b/src/views/Pools/components/PoolCard/index.tsx
@@ -6,7 +6,7 @@ import UnlockButton from 'components/UnlockButton'
 import { useTranslation } from 'contexts/Localization'
 import { BIG_ZERO } from 'utils/bigNumber'
 import { Pool } from 'state/types'
-import { getBalanceNumber } from 'utils/formatBalance'
+import { getBalanceNumber , formatNumber } from 'utils/formatBalance'
 import { getPoolBlockInfo } from 'views/Pools/helpers'
 import { useBlock } from 'state/block/hooks'
 import { getBscScanLink } from 'utils'
@@ -24,12 +24,12 @@ const PoolCard: React.FC<{ pool: Pool; account: string }> = ({ pool, account }) 
   const accountHasStakedBalance = stakedBalance.gt(0)
   const theme = useContext(ThemeContext)
 
-  const totalStaked = pool.totalStaked ? getBalanceNumber(new BigNumber(pool.totalStaked.toString()), stakingToken.decimals) : BIG_ZERO
+  const totalStaked = pool.totalStaked ? getBalanceNumber(new BigNumber(pool.totalStaked.toString()), stakingToken.decimals) : 0
 
-  const rewardPerBlock = pool?.tokenPerBlock ? getBalanceNumber(new BigNumber(pool.tokenPerBlock.toString()), earningToken.decimals) : BIG_ZERO
+  const rewardPerBlock = pool?.tokenPerBlock ? getBalanceNumber(new BigNumber(pool.tokenPerBlock.toString()), earningToken.decimals) : 0
 
   const temp = new BigNumber(pool.tokenPerBlock).times( new BigNumber(userData.stakedBalance).div(pool.totalStaked)  )
-  const rewardRate = pool?.tokenPerBlock ? getBalanceNumber(temp) : BIG_ZERO
+  const rewardRate = pool?.tokenPerBlock ? getBalanceNumber(temp) : 0
 
   const { currentBlock } = useBlock()
 
@@ -51,14 +51,14 @@ const PoolCard: React.FC<{ pool: Pool; account: string }> = ({ pool, account }) 
           <Flex justifyContent="space-between" style={{textAlign: 'left'}}>
             <Text>Remaining blocks</Text>
             <Link external href={getBscScanLink(hasPoolStarted ? endBlock : startBlock, 'countdown')}>
-              <Text>{!isComingSoon && `${blocksRemaining}`} {isComingSoon && '-'} blocks</Text>
+              <Text>{!isComingSoon && `${ formatNumber(blocksRemaining, 0, 0) }`} {isComingSoon && '-'} blocks</Text>
             </Link>
           </Flex>
 
           {/* <AprRow pool={pool} stakingTokenPrice={stakingTokenPrice} /> */}
           <Flex justifyContent="space-between" style={{textAlign: 'left'}}>
             <Text>Total Deposit</Text>
-            <Text>{!isComingSoon && `${totalStaked}`} {isComingSoon && '-'} {stakingToken.symbol}</Text>
+            <Text>{!isComingSoon && `${ formatNumber(totalStaked) }`} {isComingSoon && '-'} {stakingToken.symbol}</Text>
           </Flex>
           <Flex justifyContent="space-between" style={{textAlign: 'left'}}>
               <Text>Reward per block</Text>
@@ -70,7 +70,7 @@ const PoolCard: React.FC<{ pool: Pool; account: string }> = ({ pool, account }) 
           </Flex> */}
           <Flex justifyContent="space-between" style={{textAlign: 'left'}}>
         <Text>{t('Your Rate')}</Text>
-        <Text>{!isComingSoon && rewardRate.toFixed(4)} {isComingSoon && '-'} {pool.earningToken.symbol}/block</Text>
+        <Text>{!isComingSoon && formatNumber(rewardRate,2,10)} {isComingSoon && '-'} {pool.earningToken.symbol}/block</Text>
       </Flex>
           <Flex mt="24px" flexDirection="column" marginTop="10px">
             {account ? (


### PR DESCRIPTION
Hotfix for the claim and withdraw transaction returning "Fail with error 'Amount to withdraw too high'".

And several number formatting updates:
![image](https://user-images.githubusercontent.com/51253561/133972086-e570e938-95c4-429b-acd3-c7f7cdc85871.png)
