### PR TITLE
Add APR for farm and pools

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -36,8 +36,13 @@ export const DEFAULT_GAS_LIMIT = 200000
 export const DEFAULT_GAS_PRICE = 5
 export const TESTNET_CHAIN_ID = '97'
 export const MAINNET_CHAIN_ID = '56'
-export const EPOCH_PER_YEAR=31556926
+export const EPOCH_PER_YEAR = 31556926
 export const SPARKSWAP_API = 'https://api.sparkswap.info/api/'
+export const API_ASSETS = 'assets'
+export const API_SUMMARY = 'summary'
+export const API_LIQUIDITY = 'liquidity'
+export const API_LASTPRICE = 'last_price'
+
 
 
 export const BASE_BSC_SCAN_URLS = {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -37,6 +37,7 @@ export const DEFAULT_GAS_PRICE = 5
 export const TESTNET_CHAIN_ID = '97'
 export const MAINNET_CHAIN_ID = '56'
 export const EPOCH_PER_YEAR=31556926
+export const SPARKSWAP_API = 'https://api.sparkswap.info/api/'
 
 
 export const BASE_BSC_SCAN_URLS = {

--- a/src/hooks/price.ts
+++ b/src/hooks/price.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react'
+import { SPARKSWAP_API } from 'config'
+import useWeb3 from 'hooks/useWeb3'
+
+export const usePoolPrice = (stakingTokenAddress: string, rewardTokenAddress: string) => {
+    const [stakingPrice, setStakingPrice] = useState(0)
+    const [rewardPrice, setRewardPrice] = useState(0)
+
+    const web3 = useWeb3()
+    let _stakingTokenAddress
+    let _rewardTokenAddress
+    try{
+        _stakingTokenAddress = web3.utils.toChecksumAddress(stakingTokenAddress)
+        _rewardTokenAddress = web3.utils.toChecksumAddress(rewardTokenAddress)
+    }
+    catch{
+        console.error('Invalid staking and reward address')
+    }
+
+    useEffect(() => {
+        let asset;
+        const fetchData = async () => {
+        try {
+            console.log(SPARKSWAP_API.concat('assets'))
+            const response = await fetch(SPARKSWAP_API.concat('assets'))
+            const lastPrice = "last_price"
+            asset = await response.json();
+            
+            setStakingPrice(asset[_stakingTokenAddress][lastPrice])
+            setRewardPrice(asset[_rewardTokenAddress][lastPrice])
+        } catch (error) {
+          console.error('Unable to fetch data:', error)
+        }
+      }
+  
+      fetchData()
+    }, [setStakingPrice, setRewardPrice,_stakingTokenAddress, _rewardTokenAddress])
+
+    return {stakingPrice, rewardPrice}
+}
+
+export default usePoolPrice

--- a/src/hooks/price.ts
+++ b/src/hooks/price.ts
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react'
 import { SPARKSWAP_API } from 'config'
 import useWeb3 from 'hooks/useWeb3'
+import BigNumber from 'bignumber.js/bignumber'
+import { getBalanceNumber } from 'utils/formatBalance'
 
 export const usePoolPrice = (stakingTokenAddress: string, rewardTokenAddress: string) => {
     const [stakingPrice, setStakingPrice] = useState(0)
@@ -18,16 +20,14 @@ export const usePoolPrice = (stakingTokenAddress: string, rewardTokenAddress: st
     }
 
     useEffect(() => {
-        let asset;
         const fetchData = async () => {
         try {
-            console.log(SPARKSWAP_API.concat('assets'))
-            const response = await fetch(SPARKSWAP_API.concat('assets'))
+            let assets = await fetch(SPARKSWAP_API.concat('assets'))
+            assets = await assets.json();
             const lastPrice = "last_price"
-            asset = await response.json();
             
-            setStakingPrice(asset[_stakingTokenAddress][lastPrice])
-            setRewardPrice(asset[_rewardTokenAddress][lastPrice])
+            setStakingPrice(assets[_stakingTokenAddress][lastPrice])
+            setRewardPrice(assets[_rewardTokenAddress][lastPrice])
         } catch (error) {
           console.error('Unable to fetch data:', error)
         }
@@ -37,6 +37,59 @@ export const usePoolPrice = (stakingTokenAddress: string, rewardTokenAddress: st
     }, [setStakingPrice, setRewardPrice,_stakingTokenAddress, _rewardTokenAddress])
 
     return {stakingPrice, rewardPrice}
+}
+
+export const useFarmPrice = (lpTotalSupply: BigNumber, token1Address: string, token2Address: string, rewardTokenAddress: string) => {
+    const [LPPrice, setLPPrice] = useState(0)
+    const [rewardPrice, setRewardPrice] = useState(0)
+
+    const web3 = useWeb3()
+    let _token1Address
+    let _token2Address
+    let _rewardTokenAddress
+    try{
+        _token1Address = web3.utils.toChecksumAddress(token1Address)
+        _token2Address = web3.utils.toChecksumAddress(token2Address)
+        _rewardTokenAddress = web3.utils.toChecksumAddress(rewardTokenAddress)
+    }
+    catch{
+        console.error('Invalid staking and reward address')
+    }
+
+    useEffect(() => {
+        const fetchData = async () => {
+        try {
+
+            let assets = await fetch(SPARKSWAP_API.concat('assets'))
+            assets = await assets.json()
+            let summary = await fetch(SPARKSWAP_API.concat('summary'))
+            summary = await summary.json()
+            const lastPrice = "last_price"
+            const liquidity = "liquidity"
+            
+
+            let pairLiquidity
+
+            if(Object.prototype.hasOwnProperty.call(summary, _token1Address.concat("_",_token2Address))){
+                pairLiquidity = summary[_token1Address.concat("_",_token2Address)][liquidity];
+            }
+            else{
+                pairLiquidity = summary[_token2Address.concat("_",_token1Address)][liquidity];
+            }
+
+            setLPPrice( new BigNumber(pairLiquidity).div( getBalanceNumber(lpTotalSupply, 18) ).toNumber()  )
+            setRewardPrice(assets[_rewardTokenAddress][lastPrice])
+        } catch (error) {
+          console.error('Unable to fetch data:', error)
+        }
+      }
+  
+      fetchData()
+    }, [setLPPrice, setRewardPrice, lpTotalSupply, _token1Address, _token2Address, _rewardTokenAddress])
+
+    console.log(LPPrice)
+
+    return {LPPrice, rewardPrice}
 }
 
 export default usePoolPrice

--- a/src/utils/apr.ts
+++ b/src/utils/apr.ts
@@ -15,6 +15,7 @@ export const getPoolApr = (
   totalStaked: number,
   tokenPerBlock: number,
 ): number => {
+  
   const totalRewardPricePerYear = new BigNumber(rewardTokenPrice).times(tokenPerBlock).times(BLOCKS_PER_YEAR)
   const totalStakingTokenInPool = new BigNumber(stakingTokenPrice).times(totalStaked)
   const apr = totalRewardPricePerYear.div(totalStakingTokenInPool).times(100)

--- a/src/utils/apr.ts
+++ b/src/utils/apr.ts
@@ -1,5 +1,5 @@
 import BigNumber from 'bignumber.js'
-import { BLOCKS_PER_YEAR, CAKE_PER_YEAR } from 'config'
+import { BLOCKS_PER_YEAR, EPOCH_PER_YEAR, CAKE_PER_YEAR } from 'config'
 
 /**
  * Get the APR value in %
@@ -18,6 +18,27 @@ export const getPoolApr = (
   
   const totalRewardPricePerYear = new BigNumber(rewardTokenPrice).times(tokenPerBlock).times(BLOCKS_PER_YEAR)
   const totalStakingTokenInPool = new BigNumber(stakingTokenPrice).times(totalStaked)
+  const apr = totalRewardPricePerYear.div(totalStakingTokenInPool).times(100)
+  return apr.isNaN() || !apr.isFinite() ? null : apr.toNumber()
+}
+
+/**
+ * Get the FARM APR value in %
+ * @param LPTokenPrice LP Token price in the same quote currency
+ * @param rewardTokenPrice Token price in the same quote currency
+ * @param totalStaked Total amount of LP Token in the pool
+ * @param rewardForDuration Amount of rewards allocated to the farms
+ * @param duration Duration of the farm in EPOCH
+ * @returns Null if the APR is NaN or infinite.
+ */
+export const getFarmV2Apr = (
+  LPTokenPrice: number,
+  rewardTokenPrice: number,
+  totalStaked: number,
+  rewardRate: number
+): number => {
+  const totalRewardPricePerYear = new BigNumber(rewardTokenPrice).times(rewardRate).times(EPOCH_PER_YEAR)
+  const totalStakingTokenInPool = new BigNumber(LPTokenPrice).times(totalStaked)
   const apr = totalRewardPricePerYear.div(totalStakingTokenInPool).times(100)
   return apr.isNaN() || !apr.isFinite() ? null : apr.toNumber()
 }

--- a/src/views/Farms/components/FarmCard/FarmCard.tsx
+++ b/src/views/Farms/components/FarmCard/FarmCard.tsx
@@ -95,8 +95,6 @@ const FarmCard: React.FC<FarmCardProps> = ({ userDataReady, farm, removed, cakeP
     pairTokenAddress: farm.pairToken.address,
   })
 
-  console.log(farm)
-
   const stakingAddress = getAddress(farm.stakingAddresses);
 
   const addLiquidityUrl = `${farm.liquidityUrl ?? BASE_ADD_LIQUIDITY_URL}/${liquidityUrlPathParts}`
@@ -106,7 +104,7 @@ const FarmCard: React.FC<FarmCardProps> = ({ userDataReady, farm, removed, cakeP
   const theme = useContext(ThemeContext)
 
 
-  const {LPPrice, rewardPrice} = useFarmPrice(new BigNumber(farm.lpTotalSupply), farm.token.address[56], farm.pairToken.address[56], farm.quoteToken.address[56])
+  const {LPPrice, rewardPrice} = useFarmPrice(Number(farm.lpTotalSupply), farm.token.address[56], farm.pairToken.address[56], farm.quoteToken.address[56])
 
   const aprBlackList = ["0x9f6b80e3867ab402081574e9e0a3be6fdf4ae95b"]
   const apr = (aprBlackList.includes(farm.lpAddresses[56]) ? null : getFarmV2Apr(LPPrice, rewardPrice, Number(farm.totalDeposits), Number(farm.rewardRate)) )

--- a/src/views/Farms/components/FarmCard/FarmCard.tsx
+++ b/src/views/Farms/components/FarmCard/FarmCard.tsx
@@ -3,6 +3,8 @@ import BigNumber from 'bignumber.js'
 import styled, { keyframes, ThemeContext } from 'styled-components'
 import { Flex, Skeleton, Text } from '@sparkpointio/sparkswap-uikit'
 import { Farm } from 'state/types'
+import { useFarmPrice } from 'hooks/price'
+import { getFarmV2Apr } from 'utils/apr'
 import { useTranslation } from 'contexts/Localization'
 import { BASE_ADD_LIQUIDITY_URL, BASE_EXCHANGE_URL, BASE_INFO_URL } from 'config'
 import getLiquidityUrlPathParts from 'utils/getLiquidityUrlPathParts'
@@ -93,6 +95,8 @@ const FarmCard: React.FC<FarmCardProps> = ({ userDataReady, farm, removed, cakeP
     pairTokenAddress: farm.pairToken.address,
   })
 
+  console.log(farm)
+
   const stakingAddress = getAddress(farm.stakingAddresses);
 
   const addLiquidityUrl = `${farm.liquidityUrl ?? BASE_ADD_LIQUIDITY_URL}/${liquidityUrlPathParts}`
@@ -100,6 +104,12 @@ const FarmCard: React.FC<FarmCardProps> = ({ userDataReady, farm, removed, cakeP
   const lpAddress = farm.lpAddresses[process.env.REACT_APP_CHAIN_ID]
   const isPromotedFarm = farm.token.symbol === 'CAKE'
   const theme = useContext(ThemeContext)
+
+
+  const {LPPrice, rewardPrice} = useFarmPrice(new BigNumber(farm.lpTotalSupply), farm.token.address[56], farm.pairToken.address[56], farm.quoteToken.address[56])
+
+  const apr = getFarmV2Apr(LPPrice, rewardPrice, Number(farm.totalDeposits), Number(farm.rewardRate))
+
   return (
     <FCard isPromotedFarm={isPromotedFarm}>
       {isPromotedFarm && <StyledCardAccent />}
@@ -144,7 +154,7 @@ const FarmCard: React.FC<FarmCardProps> = ({ userDataReady, farm, removed, cakeP
       </Flex>
       <Flex justifyContent='space-between'>
         <Text>{t('APR')}</Text>
-        <Text color='textSubtle'>--</Text>
+        <Text color='textSubtle'>{(apr === 0 || apr === null ? "-- " : apr.toFixed(2))}%</Text>
       </Flex>
       <Flex justifyContent='space-between'>
         <Text>{t('Rate')}</Text>

--- a/src/views/Farms/components/FarmCard/FarmCard.tsx
+++ b/src/views/Farms/components/FarmCard/FarmCard.tsx
@@ -108,7 +108,8 @@ const FarmCard: React.FC<FarmCardProps> = ({ userDataReady, farm, removed, cakeP
 
   const {LPPrice, rewardPrice} = useFarmPrice(new BigNumber(farm.lpTotalSupply), farm.token.address[56], farm.pairToken.address[56], farm.quoteToken.address[56])
 
-  const apr = getFarmV2Apr(LPPrice, rewardPrice, Number(farm.totalDeposits), Number(farm.rewardRate))
+  const aprBlackList = ["0x9f6b80e3867ab402081574e9e0a3be6fdf4ae95b"]
+  const apr = (aprBlackList.includes(farm.lpAddresses[56]) ? null : getFarmV2Apr(LPPrice, rewardPrice, Number(farm.totalDeposits), Number(farm.rewardRate)) )
 
   return (
     <FCard isPromotedFarm={isPromotedFarm}>

--- a/src/views/Pools/components/PoolCard/index.tsx
+++ b/src/views/Pools/components/PoolCard/index.tsx
@@ -1,16 +1,17 @@
 import BigNumber from 'bignumber.js'
-import React, { useContext } from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 import { CardBody, Flex, Text , Link, LinkExternal} from '@sparkpointio/sparkswap-uikit'
 import { ThemeContext } from 'styled-components'
 import UnlockButton from 'components/UnlockButton'
 import { useTranslation } from 'contexts/Localization'
 import { BIG_ZERO } from 'utils/bigNumber'
+import { usePoolPrice } from 'hooks/price'
+import { getPoolApr } from 'utils/apr'
 import { Pool } from 'state/types'
 import { getBalanceNumber , formatNumber } from 'utils/formatBalance'
 import { getPoolBlockInfo } from 'views/Pools/helpers'
 import { useBlock } from 'state/block/hooks'
 import { getBscScanLink } from 'utils'
-import AprRow from './AprRow'
 import { StyledCard, StyledCardInner } from './StyledCard'
 import CardFooter from './CardFooter'
 import StyledCardHeader from './StyledCardHeader'
@@ -35,6 +36,10 @@ const PoolCard: React.FC<{ pool: Pool; account: string }> = ({ pool, account }) 
 
   const { shouldShowBlockCountdown, blocksUntilStart, blocksRemaining, hasPoolStarted, blocksToDisplay } =
   getPoolBlockInfo(pool, currentBlock)
+
+  const {stakingPrice, rewardPrice} = usePoolPrice(stakingToken.address[56], earningToken.address[56])
+
+  const apr = getPoolApr(stakingPrice, rewardPrice, totalStaked, rewardPerBlock)
 
   return (
     <StyledCard
@@ -64,10 +69,10 @@ const PoolCard: React.FC<{ pool: Pool; account: string }> = ({ pool, account }) 
               <Text>Reward per block</Text>
               <Text>{!isComingSoon && rewardPerBlock} {isComingSoon && '-'}</Text>
           </Flex>
-          {/* <Flex justifyContent="space-between" style={{textAlign: 'left'}}>
+          <Flex justifyContent="space-between" style={{textAlign: 'left'}}>
             <Text>APY</Text>
-            <Text>0%</Text>
-          </Flex> */}
+            <Text>{(apr === 0 || apr === null ? "-- " : apr.toFixed(2))}%</Text>
+          </Flex>
           <Flex justifyContent="space-between" style={{textAlign: 'left'}}>
         <Text>{t('Your Rate')}</Text>
         <Text>{!isComingSoon && formatNumber(rewardRate,2,10)} {isComingSoon && '-'} {pool.earningToken.symbol}/block</Text>


### PR DESCRIPTION
Add: APR for farms and pools.
To follow: APR for farms and pools with LP and staking tokens outside SparkSwap
![image](https://user-images.githubusercontent.com/51253561/135075590-a5b57db2-c2b2-4c61-9997-088dc7fec759.png)
![image](https://user-images.githubusercontent.com/51253561/135075617-920da277-da6a-4251-a626-559bc6fee724.png)
