### PR TITLE
Update sparkdefi page title typo

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,7 +12,7 @@
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <!-- Meta -->
-    <title>SparkDefi</title>
+    <title>SparkDeFi</title>
     <meta
       name="description"
       content="Refuel your rocket with SFUEL and travel to the moon with SparkDefi, the prodigious decentralized exchange on Binance Smart Chain"


### PR DESCRIPTION
- [x] Quick fix for page title typo

Page title typo
<img width="133" alt="sparkdefi_title_typo" src="https://user-images.githubusercontent.com/50922758/137246735-00dfae89-cc4f-4127-8adc-9f4fe37f9c06.png">

Fix
<img width="120" alt="fixed_sparkdefi_title_typo" src="https://user-images.githubusercontent.com/50922758/137246774-20e4498c-6c08-457d-b9d3-f838be7b629b.png">

